### PR TITLE
Replace the missing 'getKey' function.

### DIFF
--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -10,6 +10,19 @@ export default function init() {
 	addListeners();
 }
 
+/**
+ * The original version of this function was removed in Foundry VTT v9.
+ */
+export function getKey(event) {
+    if ( event.code === "Space" ) return event.code;
+    if ( /^Digit/.test(event.code) ) return event.code[5];
+    if ( (event.location === 3) && ((event.code in game.keyboard.moveKeys) || (event.code in game.keyboard.zoomKeys)) ) {
+        return event.code;
+    }
+    return event.key;
+}
+
+
 function setUpControls(settings) {
 	controls = { pointer: {}, ping: {}, force: {} };
 
@@ -101,7 +114,7 @@ function checkKey(ev, obj) {
 	if (ev.target !== document.body && ev.target !== canvas.app.view) return false;
 	// if (document.activeElement !== document.body) return false;
 
-	const key = game.keyboard.getKey(ev);
+	const key = getKey(ev);
 	if (key) {
 		if (key?.toUpperCase() !== obj.key?.toUpperCase()) return false;
 	} else {

--- a/js/settings/settings.js
+++ b/js/settings/settings.js
@@ -1,4 +1,5 @@
 import { Pointer } from '../pixi/pointer.js';
+import { getKey } from '../keybindings.js';
 
 export class PointerSettingsMenu extends FormApplication {
 	static get defaultOptions() {
@@ -432,12 +433,12 @@ export class PointerSettingsMenu extends FormApplication {
 				this._focusedControl = ev.currentTarget;
 				return;
 			}
-			let key = game.keyboard.getKey(ev);
+			let key = getKey(ev);
 			if (['Control', 'Shift', 'Alt', 'Meta'].includes(key)) {
 				ev.currentTarget.value = key;
 				return;
 			}
-			ev.currentTarget.value = this._getMetaKeys(ev) + game.keyboard.getKey(ev).toUpperCase();
+			ev.currentTarget.value = this._getMetaKeys(ev) + getKey(ev).toUpperCase();
 		});
 	}
 

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"name": "pointer",
 	"title": "PnP - Pointer and Pings!",
 	"description": "Gives all players the option to show a customizable cursor on demand, as well as ping any location with a custom ping!<br>Hotkeys, pings, pointer, everything customizable!<br>As GM you can also move your players view to your pin on demand.",
-	"version": "2.3.3",
+	"version": "2.3.4",
 	"author": "Moerill",
 	"esmodules": ["js/index.js"],
 	"styles": ["fvtt-pointer.css"],
@@ -21,11 +21,11 @@
 			"path": "lang/es.json"
 		}
 	],
-	"minimumCoreVersion": "0.8.1",
-	"compatibleCoreVersion": "0.8.9",
+	"minimumCoreVersion": "9.238",
+	"compatibleCoreVersion": "9.238",
 	"socket": true,
 	"manifest": "https://raw.githubusercontent.com/Moerill/fvtt-pointer/master/module.json",
-	"download": "https://github.com/Moerill/fvtt-pointer/releases/download/v2.3.3/v2.3.3.zip",
+	"download": "https://github.com/Moerill/fvtt-pointer/releases/download/v2.3.4/v2.3.4.zip",
 	"url": "https://github.com/Moerill/fvtt-pointer",
 	"bugs": "https://github.com/Moerill/fvtt-pointer/issues",
 	"allowBugReporter": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "module-template",
-	"version": "2.3.3",
+	"version": "2.3.4",
 	"description": "",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Replacing this function restores the original functionality of PnP
as-is. The bindings will not show up in the standard bindings interface. There is not an easy way to do both.

Resolves #29.