### PR TITLE
add japanese localization location

### DIFF
--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1,0 +1,4 @@
+{
+    "localization-location":"You can find the japanese localization at the centralized localization module. It can be found here https://github.com/BrotherSharper/foundryVTTja",
+    "localization-location-ja":"この翻訳ファイルは本体日本語化Modに存在します。こちらから入手してください https://github.com/BrotherSharper/foundryVTTja"
+  }

--- a/module.json
+++ b/module.json
@@ -24,6 +24,11 @@
 			"lang": "de",
 			"name": "Deutsch",
 			"path": "lang/de.json"
+		},
+		{
+			"lang": "ja",
+			"name": "日本語",
+			"path": "lang/ja.json"
 		}
 	],
 	"minimumCoreVersion": "9.238",


### PR DESCRIPTION
Hey there, the Japanese localization for this module has been added to the centralized localization module.
If you would like to, you can merge this so that your module appears as being localized for the purpose of searching sites such as Foundry Hub/Forge.