### PR TITLE
Support Foundry v11 alongside v10

### DIFF
--- a/js/pixi/container.js
+++ b/js/pixi/container.js
@@ -87,9 +87,12 @@ export class PointerContainer extends PIXI.Container {
   }
 
   getMouseWorldCoord() {
-    return canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(
-      canvas.stage
-    );
+    if (canvas.app.renderer.events) {
+      // PixiJS 7 (Foundry VTT 11)
+      return canvas.app.renderer.events.pointer.getLocalPosition(canvas.stage);
+    }
+
+    return canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.stage);
   }
 
   ping({

--- a/module.json
+++ b/module.json
@@ -26,8 +26,8 @@
   ],
   "compatibility": {
     "minimum": "10",
-    "verified": "10.285",
-    "maximum": "10"
+    "verified": "11.300",
+    "maximum": "11"
   },
   "socket": true,
   "manifest": "https://raw.githubusercontent.com/Moerill/fvtt-pointer/master/module.json",


### PR DESCRIPTION
Update to support Foundry VTT 11, due to API change in PixiJS 7.
Fixes #49 